### PR TITLE
sns_authenticate2

### DIFF
--- a/app/helpers/sns_login_helper.rb
+++ b/app/helpers/sns_login_helper.rb
@@ -1,0 +1,25 @@
+module SnsLoginHelper 
+  def facebook
+    authorization
+  end
+
+  def google_oauth2
+    authorization
+  end
+
+  def failure
+    redirect_to root_path
+  end
+
+  private
+
+  def authorization
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
+    else
+      render template: 'users/registrations/new'
+    end
+  end
+end

--- a/app/models/sns_credential.rb
+++ b/app/models/sns_credential.rb
@@ -1,0 +1,3 @@
+class SnsCredential < ApplicationRecord
+  belongs_to :user, optional: true
+end

--- a/db/migrate/20191101173852_create_sns_credentials.rb
+++ b/db/migrate/20191101173852_create_sns_credentials.rb
@@ -1,0 +1,10 @@
+class CreateSnsCredentials < ActiveRecord::Migration[5.2]
+  def change
+    create_table :sns_credentials do |t|
+      t.string :provider
+      t.string :uid
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
# What
SNSでのログイン認証機能を実装するためにモデルを追加し、helperモジュールを作成した。

# Why
ファットコントローラーになることを防ぐため、helperモジュールを作成。
機能実装に必要なmigrationファイルとモデルを作成。

# How
helpersのディレクトリにsns_login_helper.rbを作成
gem omuniauthの　githubを参照し、SNS認証に必要なメソッドを記述。
合わせてモデルのアソシエーションとmigrationファイルを作成。